### PR TITLE
Fix for plugin incompatibility issue with PHP Storm 2023.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
 }
 
 group 'com.interfaced'
-version '0.2.7'
+version '0.2.8.2'
 
 apply plugin: 'kotlin'
 apply plugin: 'org.jetbrains.intellij'
@@ -56,6 +56,7 @@ intellij {
 }
 
 patchPluginXml {
+    untilBuild = providers.gradleProperty('pluginUntilBuild')
 }
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,27 @@
+# Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
+pluginUntilBuild = 233.*
+
+# IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
+platformType = IC
+platformVersion = 2022.3.3
+
+platformTypes = IC,RD
+
+# Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
+# Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
+platformPlugins =
+
+# Gradle Releases -> https://github.com/gradle/gradle/releases
+gradleVersion = 8.4
+
+# Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
+kotlin.stdlib.default.dependency = false
+
+# Enable Gradle Configuration Cache -> https://docs.gradle.org/current/userguide/configuration_cache.html
+org.gradle.configuration-cache = true
+
+# Enable Gradle Build Cache -> https://docs.gradle.org/current/userguide/build_cache.html
+org.gradle.caching = true
+
+# Enable Gradle Kotlin DSL Lazy Property Assignment -> https://docs.gradle.org/current/userguide/kotlin_dsl.html#kotdsl:assignment
+systemProp.org.gradle.unsafe.kotlin.assignment = true


### PR DESCRIPTION
Wanted to give this a try and it wouldn't allow me to install the plugin, so a few tweaks to bump the untilBuild value to something more recent.  